### PR TITLE
Enable setting spike hoops from API

### DIFF
--- a/pycbsdk/cbhw/device/nsp.py
+++ b/pycbsdk/cbhw/device/nsp.py
@@ -529,6 +529,29 @@ class NSPDevice(DeviceInterface):
         pkt.spkopts |= CBAInpSpk.THRAUTO.value if attr_value else 0
         self._send_packet(pkt)
 
+    def _configure_channel_hoops(self, chid: int, attr_value: dict):
+        """
+        Args:
+            chid: 1-based channel index
+            attr_value: a dictionary of dictionaries of dictionaries.
+                The outer dictionary keys are the 1-based unit ids.
+                The middle dictionary keys are the 1-based hoop ids.
+                The inner dictionary has fields 'time', 'min', and 'max'.
+                e.g. attr_value = {1: {
+                    1: {'time': 13, 'min': -975, 'max': -646},
+                    2: {'time': 6, 'min': 108, 'max': 342}
+                }
+                This will set the first two hoops for unit-1.
+        """
+        pkt = copy.copy(self._config["channel_infos"][chid])
+        pkt.header.type = CBPacketType.CHANSETSPKHPS
+        for un_id, hoop_dicts in attr_value.items():
+            for hp_id, hp in hoop_dicts.items():
+                pkt.spkhoops[un_id-1][hp_id-1] = CBHoop(
+                    valid=1, time=hp["time"], min=hp["min"], max=hp["max"]
+                )
+        self._send_packet(pkt)
+
     def _configure_channel_label(self, chid: int, attr_value: str):
         pkt = copy.copy(self._config["channel_infos"][chid])
         pkt.header.type = CBPacketType.CHANSETLABEL
@@ -587,6 +610,8 @@ class NSPDevice(DeviceInterface):
             self._configure_channel_enable_spike(chid, attr_value)
         elif attr_name.lower().startswith("autothresh"):
             self._configure_channel_autothreshold(chid, attr_value)
+        elif attr_name.lower().startswith("hoops"):
+            self._configure_channel_hoops(chid, attr_value)
         # self._config_events["chaninfo"].wait(timeout=0.02)
 
     def configure_all_channels_spike(

--- a/pycbsdk/cbhw/device/nsp.py
+++ b/pycbsdk/cbhw/device/nsp.py
@@ -45,6 +45,7 @@ from pycbsdk.cbhw.packet.common import (
     CBNPlayMode,
     CBNPlayFlag,
     CBSpecialChan,
+    CBHoop
 )
 from pycbsdk.cbhw.params import Params
 from pycbsdk.cbhw.consts import CBError
@@ -556,7 +557,11 @@ class NSPDevice(DeviceInterface):
         pkt = copy.copy(self._config["channel_infos"][chid])
         pkt.header.type = CBPacketType.CHANSETSPK
         pkt.spkopts &= ~CBAInpSpk.EXTRACT.value
-        pkt.spkopts |= CBAInpSpk.EXTRACT.value if attr_value else 0
+        if attr_value:
+            pkt.spkopts |= CBAInpSpk.EXTRACT.value if attr_value else 0
+            # Also reset sorting. Enable hoops by default.
+            pkt.spkopts &= ~CBAInpSpk.ALLSORT.value
+            pkt.spkopts |= CBAInpSpk.HOOPSORT.value
         self._send_packet(pkt, self._config_events["chaninfo"])
 
     def configure_channel(self, chid: int, attr_name: str, attr_value):

--- a/pycbsdk/cbhw/packet/packets.py
+++ b/pycbsdk/cbhw/packet/packets.py
@@ -377,7 +377,7 @@ class CBPacketNTrodeInfo(CBPacketConfigFixed):
             "_label",
             c_char * 16,
         ),  # Label of the Ntrode (null terminated if < 16 characters)
-        ("ellipses", CBManualUnitMapping * 6 * 5),
+        ("ellipses", CBManualUnitMapping * 5 * 6),
         (
             "nSite",
             c_uint16,

--- a/pycbsdk/cbhw/packet/v311.py
+++ b/pycbsdk/cbhw/packet/v311.py
@@ -107,7 +107,7 @@ class CBPacketChanInfo(CBPacketConfigFixed):
         ("amplrejneg", c_int16),  # Amplitude rejection negative value
         ("refelecchan", c_uint32),  # Software reference electrode channel
         ("unitmapping", CBManualUnitMapping * 5),  # manual unit mapping
-        ("spkhoops", CBHoop * 5 * 4),  # spike hoop sorting set
+        ("spkhoops", CBHoop * 4 * 5),  # spike hoop sorting set
     ]
 
     @property

--- a/pycbsdk/cbhw/packet/v41.py
+++ b/pycbsdk/cbhw/packet/v41.py
@@ -104,7 +104,7 @@ class CBPacketChanInfo(CBPacketConfigFixed):
         ("amplrejneg", c_int16),  # Amplitude rejection negative value
         ("refelecchan", c_uint32),  # Software reference electrode channel
         ("unitmapping", CBManualUnitMapping * 5),  # manual unit mapping
-        ("spkhoops", CBHoop * 5 * 4),  # spike hoop sorting set
+        ("spkhoops", CBHoop * 4 * 5),  # spike hoop sorting set
     ]
 
     @property

--- a/pycbsdk/examples/print_rates.py
+++ b/pycbsdk/examples/print_rates.py
@@ -64,6 +64,7 @@ def main(
     loglevel: str = "debug",
     skip_startup: bool = False,
     update_interval: float = 1.0,
+    set_hoops: bool = False
 ):
     """
     Run the application:
@@ -87,6 +88,7 @@ def main(
     :param loglevel: debug, info, or warning
     :param skip_startup: Skip the initial handshake as well as the attempt to set the device to RUNNING.
     :param update_interval: Interval between updates. This determines how big the queues can grow.
+    :param set_hoops: set True to enable hoop-based sorting on channel 2.
     :return:
     """
     # Handle logger arguments
@@ -151,6 +153,23 @@ def main(
     for ch_type in [CBChannelType.FrontEnd, CBChannelType.AnalogIn]:
         cbsdk.set_all_channels_disable(nsp_obj, ch_type)
         cbsdk.set_all_channels_spk_config(nsp_obj, ch_type, "enable", True)
+
+    if set_hoops:
+        spk_hoops = {
+            1: {
+                1: {"time": 13, "min": -975, "max": -646},
+                2: {"time": 6, "min": 108, "max": 342},
+            },
+            2: {
+                1: {"time": 21, "min": 675, "max": 1033},
+                2: {"time": 31, "min": -538, "max": -185},
+            },
+            3: {
+                1: {"time": 17, "min": 481, "max": 820},
+                2: {"time": 35, "min": -23, "max": 262},
+            },
+        }
+        cbsdk.set_channel_spk_config(nsp_obj, 2, "hoops", spk_hoops)
 
     # Count the number of FrontEnd | AnalogIn channels.
     b_spk = [


### PR DESCRIPTION
Fixes #4 

This adds API functions to set spike hoops. It also fixes a problem in the declaration of arrays of arrays like `spkhoops`. It turns out that the order should be `struct_name * inner * outer` when the field is indexed as `field_name[outer_idx][inner_idx]`.