### PR TITLE
Expose monitor state

### DIFF
--- a/src/pycbsdk/cbhw/device/nsp.py
+++ b/src/pycbsdk/cbhw/device/nsp.py
@@ -1131,6 +1131,9 @@ class NSPDevice(DeviceInterface):
             self.set_transport("CHECK", True, timeout=0.5)
         return self._config["transport"]
 
+    def get_monitor_state(self) -> dict:
+        return self._monitor_state.copy()
+
     def reset(self) -> int:
         print("TODO: reset NSP proctime to 0")
         return 0

--- a/src/pycbsdk/cbhw/device/nsp.py
+++ b/src/pycbsdk/cbhw/device/nsp.py
@@ -472,6 +472,7 @@ class NSPDevice(DeviceInterface):
         self._config["nplay"] = pkt
 
     def _handle_procmon(self, pkt):
+        arrival_time = time.time()
         update_interval = max(pkt.header.time - self._monitor_state["time"], 1)
         pkt_delta = self.pkts_received - self._monitor_state["pkts_received"]
 
@@ -492,6 +493,7 @@ class NSPDevice(DeviceInterface):
             "counter": pkt.counter if has_counter else -1,
             "time": pkt.header.time,
             "pkts_received": self.pkts_received,
+            "sys_time": arrival_time,
         }
 
     def _handle_log(self, pkt):

--- a/src/pycbsdk/cbsdk.py
+++ b/src/pycbsdk/cbsdk.py
@@ -170,6 +170,10 @@ def get_runlevel(device: NSPDevice) -> CBRunLevel:
     return device.get_runlevel()
 
 
+def get_monitor_state(device: NSPDevice) -> dict:
+    return device.get_monitor_state()
+
+
 def register_event_callback(
     device: NSPDevice, channel_type: CBChannelType, func: Callable[[Structure], None]
 ):


### PR DESCRIPTION
* Monitor state records packet arrival time
* Add method to obtain monitor state

This can be useful to compare device and system timestamps if one is willing to accept the inaccuracy due to packet transmission latency.